### PR TITLE
Expose some ctypes for extension libraries

### DIFF
--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -550,8 +550,10 @@ val unsafe_pixel_format_of_ptr : int64 -> pixel_format
 (** {2:surfaces
     {{:http://wiki.libsdl.org/CategorySurface}Surface}} *)
 
-type surface 
+type surface
 (** {{:https://wiki.libsdl.org/SDL_Surface}SDL_Surface} *)
+val surface : surface Ctypes.typ
+val surface_opt : surface option Ctypes.typ
 
 val blit_scaled : src:surface -> rect -> dst:surface -> rect option -> 
   unit result
@@ -717,14 +719,19 @@ module Flip : sig
   val vertical : flip
 end
 
-type texture 
+type texture
 (** SDL_Texture *)
+
+val texture : texture Ctypes.typ
+val texture_opt : texture option Ctypes.typ
 
 (**/**)
 val unsafe_texture_of_ptr : int64 -> texture
 (**/**)
 
 type renderer
+val renderer : renderer Ctypes.typ
+val renderer_opt : renderer option Ctypes.typ
 
 (**/**)
 val unsafe_renderer_of_ptr : int64 -> renderer

--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -290,8 +290,9 @@ val get_revision_number : unit -> int
 
 (** {2:io {{:https://wiki.libsdl.org/CategoryIO}IO abstraction}} *) 
 
-type rw_ops 
+type rw_ops
 (** {{:https://wiki.libsdl.org/SDL_RWops}SDL_RWops} *)
+val rw_ops : rw_ops Ctypes.typ
 
 val rw_from_file : string -> string -> rw_ops result
 (** {{:https://wiki.libsdl.org/SDL_RWFromFile}SDL_RWFromFile} *)


### PR DESCRIPTION
In order to create bindings to SDL2_image and SDL2_mixer, I needed to expose some of the types they use.

I would appreciate feedback on whether this is the right approach, and what I would need to do with these changes to get them merged.