### PR TITLE
Add a modify function for rects

### DIFF
--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -494,6 +494,13 @@ module Rect = struct
     setf r rect_h h; 
     r
 
+  let modify r ~x ~y ~w ~h =
+    setf r rect_x x;
+    setf r rect_y y;
+    setf r rect_w w;
+    setf r rect_h h;
+    r
+
   let x r = getf r rect_x 
   let y r = getf r rect_y
   let w r = getf r rect_w 

--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -353,6 +353,7 @@ type rect
 
 module Rect : sig
   val create : x:int -> y:int -> w:int -> h:int -> rect
+  val modify : rect -> x:int -> y:int -> w:int -> h:int -> rect
   val x : rect -> int
   val y : rect -> int 
   val w : rect -> int 


### PR DESCRIPTION
Without a way to modify rects, programs that use them in must cons new
ones every time.  With no option to give them dynamic extent, this
can create a huge amount of garbage.

I needed to create this modification to get Zookicker (http://github.com/tokenrove/zookicker) running, a trivial game using tsdl, but I appreciate that it is probably not the most elegant approach.

I would appreciate feedback on how this goal could be achieved in a way that fits tsdl's design.