### PR TITLE
Update required OCaml version

### DIFF
--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/tsdl/issues"
 tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
         "org:erratique" ]
 license: "ISC"
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.02.0" ]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
Commit 46ffd02e86739454a2000e221a9ac23dbbbc0a91 introduces the use of
ocamlbuild's `mark_tag_used`, which does not exist until OCaml 4.02.0.

(This causes CI builds to fail for 4.01.0.)