### PR TITLE
quick fix of undeclared constants errors occurring with SDL 2.0.4

### DIFF
--- a/support/consts_stub.c
+++ b/support/consts_stub.c
@@ -11,6 +11,22 @@
 #include <caml/mlvalues.h>
 #include "SDL.h"
 
+#ifndef SDL_DROPTEXT
+  #define SDL_DROPTEXT 0
+#endif
+#ifndef SDL_DROPBEGIN
+  #define SDL_DROPBEGIN 0
+#endif
+#ifndef SDL_DROPCOMPLETE
+  #define SDL_DROPCOMPLETE 0
+#endif
+#ifndef SDL_WINDOWEVENT_TAKE_FOCUS
+  #define SDL_WINDOWEVENT_TAKE_FOCUS 0
+#endif
+#ifndef SDL_WINDOWEVENT_HIT_TEST
+  #define SDL_WINDOWEVENT_HIT_TEST 0
+#endif
+
 void let (FILE *fd, const char *symb)
 {
   int i;


### PR DESCRIPTION
I found `opam install tsdl` is failed with SDL 2.0.4 because some constants are not declared.
Finally I defined them as '0' in "SDL.h", and successfully install tsdl 0.9.2 with opam 1.2.2.
FYI, OCaml version is 4.04.0 on Linux Mint 18.

The constants not declared in SDL 2.0.4 (but exist in SDL 2.0.5) are:

 - SDL_DROPTEXT
 - SDL_DROPBEGIN
 - SDL_DROPCOMPLETE
 - SDL_WINDOWEVENT_TAKE_FOCUS
 - SDL_WINDOWEVENT_HIT_TEST

I know letting them '0' is not the way to go, but I can't find out good way.
If you have time, fix this problem please.

Thank you for your great efforts.