### PR TITLE
add Init.nothing

### DIFF
--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -181,6 +181,7 @@ module Init = struct
   let ( + ) = Unsigned.UInt32.logor
   let test f m = Unsigned.UInt32.(compare (logand f m) zero <> 0)
   let eq f f' = Unsigned.UInt32.(compare f f' = 0)
+  let nothing = i 0
   let timer = i sdl_init_timer
   let audio = i sdl_init_audio
   let video = i sdl_init_video

--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -113,6 +113,7 @@ module Init : sig
   val eq : t -> t -> bool
   (** [eq f f'] is [true] if the flags are equal. *)
 
+  val nothing : t
   val timer : t
   val audio : t
   val video : t


### PR DESCRIPTION
In order to follow the SDL doc:
  See https://wiki.libsdl.org/SDL_Init
   "If you want to initialize subsystems separately you would call SDL_Init(0)
   followed by SDL_InitSubSystem() with the desired subsystem flag. "