### PR TITLE
Add identifier for MessageBox buttons with no default key

### DIFF
--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -2280,6 +2280,7 @@ module Message_box = struct
   type button_flags = Unsigned.uint32
   let button_returnkey_default = i sdl_messagebox_button_returnkey_default
   let button_escapekey_default = i sdl_messagebox_button_escapekey_default
+  let button_no_default = i 0
 
   type button_data =
     { button_flags : button_flags;

--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -1556,6 +1556,7 @@ module Message_box : sig
   type button_flags
   val button_returnkey_default : button_flags
   val button_escapekey_default : button_flags
+  val button_no_default : button_flags
 
   type button_data =
     { button_flags : button_flags;

--- a/test/test.ml
+++ b/test/test.ml
@@ -914,6 +914,10 @@ let test_message_boxes human =
                button_id = 2;
                button_text = "Action" }
     in
+	let other = { button_flags = button_no_default;
+               button_id = 3;
+               button_text = "Other" }
+    in
     let color_scheme = { color_background = (255, 255, 255);
                          color_text = (255, 0, 0);
                          color_button_border = (0, 255, 0);
@@ -921,12 +925,12 @@ let test_message_boxes human =
                          color_button_selected = (0, 255, 255); }
     in
     { flags = warning; window = None; title = "Action";
-      message = "Do you want to action ?"; buttons = [undo; action];
+	  message = "Do you want to action ?"; buttons = [undo; action; other];
       color_scheme = Some color_scheme }
   in
   begin match Sdl.show_message_box d with
   | Error (`Msg e) -> log_err " Could not show message box: %s" e
-  | Ok 1 | Ok 2 -> ()
+  | Ok 1 | Ok 2 | Ok 3 -> ()
   | Ok _ -> assert false
   end;
   ()

--- a/test/test.ml
+++ b/test/test.ml
@@ -925,7 +925,7 @@ let test_message_boxes human =
                          color_button_selected = (0, 255, 255); }
     in
     { flags = warning; window = None; title = "Action";
-	  message = "Do you want to action ?"; buttons = [undo; action; other];
+      message = "Do you want to action ?"; buttons = [undo; action; other];
       color_scheme = Some color_scheme }
   in
   begin match Sdl.show_message_box d with


### PR DESCRIPTION
Default keys in a message box allows for buttons to be "clicked" when the user presses a key.

There are three flags a button can have, according to the documentation:
https://wiki.libsdl.org/SDL_ShowMessageBox

- Return key: The button is pressed when the user presses 'Enter'
- Escape key: The button is pressed when the user presses 'Escape'
- No flags: the button must be clicked in order to be selected

Tsdl is missing an identifier for the "No flags", which is 0.