### PR TITLE
Sdl.{queue_audio,dequeue_audio}: the size argument should be in bytes

### DIFF
--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -5127,7 +5127,8 @@ let queue_audio =
 
 let queue_audio dev ba =
   let len = Bigarray.Array1.dim ba in
-  queue_audio dev (to_voidp (bigarray_start array1 ba)) len
+  let kind_size = ba_kind_byte_size (Bigarray.Array1.kind ba) in
+  queue_audio dev (to_voidp (bigarray_start array1 ba)) (len * kind_size)
 
 let dequeue_audio =
   foreign "SDL_DequeueAudio"
@@ -5135,7 +5136,8 @@ let dequeue_audio =
 
 let dequeue_audio dev ba =
   let len = Bigarray.Array1.dim ba in
-  dequeue_audio dev (to_voidp (bigarray_start array1 ba)) len
+  let kind_size = ba_kind_byte_size (Bigarray.Array1.kind ba) in
+  dequeue_audio dev (to_voidp (bigarray_start array1 ba)) (len * kind_size)
 
 let get_queued_audio_size =
   foreign "SDL_GetQueuedAudioSize"

--- a/test/test_audio_queue.ml
+++ b/test/test_audio_queue.ml
@@ -37,14 +37,14 @@ let audio_setup () =
   | Error _ -> Sdl.log "Can't open audio device"; exit 1
   | Ok (device_id, _) -> device_id
   in
-  (* Create a few seconds of audio data *)
-  let dim = channels * audio_freq * 10 in
+  let dim = channels * audio_freq in
   let buffer = Bigarray.(Array1.create int32 c_layout dim) in
   let () = create_audio buffer in
   (dev, buffer)
 
 let queue_and_start_audio device_id buffer =
-  Sdl.log "Size of buffer to queue: %d" (Bigarray.Array1.dim buffer);
+  (* multiply dim by 4 (int32 is 4 bytes), to account for queue_audio sizing. *)
+  Sdl.log "Size of buffer to queue: %d" (Bigarray.Array1.dim buffer * 4);
   match Sdl.queue_audio device_id buffer with
   | Ok () ->
       (* Let's query how much is queued up before we start playing. *)


### PR DESCRIPTION
This addresses issue #63
I think `dequeue` and `queue` were the only impacted functions.
I took a look at the testsuite and adjusted the `test_audio_queue` case to properly account for the sizing returned by SDL. (however, pardon the wild multiplication in this specific use case, as `ba_kind_byte_size` is handful, but an internal to Tsdl.).

Tell me if there's anything to improve,
Have a great day.
