### PR TITLE
add binding to SDL_SetWindowInputFocus

### DIFF
--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -2112,6 +2112,9 @@ let set_window_grab =
 let set_window_icon =
   foreign "SDL_SetWindowIcon" (window @-> surface @-> returning void)
 
+let set_window_input_focus =
+  foreign "SDL_SetWindowInputFocus" (window @-> returning zero_to_ok)
+
 let set_window_maximum_size =
   foreign "SDL_SetWindowMaximumSize"
     (window @-> int @-> int @-> returning void)

--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -1344,6 +1344,9 @@ val set_window_grab : window -> bool -> unit
 val set_window_icon : window -> surface -> unit
 (** {{:http://wiki.libsdl.org/SDL_SetWindowIcon}SDL_SetWindowIcon} *)
 
+val set_window_input_focus : window -> unit result
+(** {{:http://wiki.libsdl.org/SDL_SetWindowInputFocus}SDL_SetWindowInputFocus} *)
+
 val set_window_maximum_size : window -> w:int -> h:int -> unit
 (** {{:http://wiki.libsdl.org/SDL_SetWindowMaximumSize}
     SDL_SetWindowMaximumSize} *)


### PR DESCRIPTION
This was introduced in SDL 2.05 (see https://wiki.libsdl.org/SDL_SetWindowInputFocus).