### PR TITLE
Use .obj (etc.) when using compilers like MSVC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   Thanks to Maxence Guesdon for the patch.
 - Add `rw_from_const_mem`.
   Thanks to Maxence Guesdon for the patch.
+- Use `.obj` and other non-`.o` object extensions for compilers
+  like MSVC.
 
 v0.9.9 2022-05-31 Zagreb
 ------------------------

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -34,10 +34,15 @@ let pkg_config_lib ~lib ~has_lib ~stublib =
   flag ["link"; "ocaml"; tag] (S (link_flags @ lib_flags));
   flag ["link"; "ocaml"; "library"; "byte"; tag] (S stublib_flags)
 
+let obj s =
+  match !Ocamlbuild_plugin.Options.ext_obj with
+  | "" -> s ^ ".o"
+  | x -> s ^ "." ^ x
+
 (* tsdl_const.ml generation. *)
 
 let sdl_consts_build () =
-  dep [ "link"; "ocaml"; "link_consts_stub" ] [ "support/consts_stub.o" ];
+  dep [ "link"; "ocaml"; "link_consts_stub" ] [ obj "support/consts_stub" ];
   dep [ "sdl_consts" ] [ "src/tsdl_consts.ml" ];
   rule "sdl_consts: consts.byte -> tsdl_consts.ml"
     ~dep:"support/consts.byte"


### PR DESCRIPTION
Problem: The original build file pre-supposed a `.o` extension, which ended with an ocamlbuild Solver error.

Solution: Changed it to use `.obj` from the ocamlbuild plugin, similar to the method used in https://github.com/dbuenzli/mtime/blob/f4cf3aea9cdc24e267d9a0f7fa8b2374ff3e3627/myocamlbuild.ml#L11-L14

(I still don't have `tsdl` working on native Windows yet, but it gets past the solver error with this PR).

---

Full problem log from `opam pin tsdl -k version 0.9.9`:

```
 ocamlfind ocamlopt unix.cmxa -I 'C:\Users\beckf\AppData\Local\opam\playground\lib/ocaml\ocamlbuild' 'C:\Users\beckf\AppData\Local\opam\playground\lib/ocaml\ocamlbuild/ocamlbuildlib.cmxa' -linkpkg myocamlbuild.ml 'C:\Users\beckf\AppData\Local\opam\playground\lib/ocaml\ocamlbuild/ocamlbuild.cmx' -o myocamlbuild.exe
 ocamlfind ocamldep -modules support/consts.ml > support/consts.ml.depends
 ocamlfind ocamlc -c -g -bin-annot -safe-string -thread -I support -I test -I src -o support/consts.cmo support/consts.ml
Solver failed:
  Ocamlbuild knows of no rules that apply to a target named src/tsdl.cmx. This can happen if you ask Ocamlbuild to build a target with the wrong extension (e.g. .opt instead of .native) or if the source files live in directories that have not been specified as include directories.
Backtrace:
  - Failed to build the target src/tsdl.lib
      - Building src/tsdl.lib:
          - Failed to build all of these:
              - Building src/tsdl.cmx
              - Failed to build all of these:
                  - Building support/Tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building support/Tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building support/Tsdl_consts.mly
                                  - Building support/Tsdl_consts.mll
                          - Building support/Tsdl_consts.mlpack
                  - Building support/tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building support/tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building support/tsdl_consts.mly
                                  - Building support/tsdl_consts.mll
                          - Building support/tsdl_consts.mlpack
                  - Building test/Tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building test/Tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building test/Tsdl_consts.mly
                                  - Building test/Tsdl_consts.mll
                          - Building test/Tsdl_consts.mlpack
                  - Building test/tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building test/tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building test/tsdl_consts.mly
                                  - Building test/tsdl_consts.mll
                          - Building test/tsdl_consts.mlpack
                  - Building Tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building Tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building Tsdl_consts.mly
                                  - Building Tsdl_consts.mll
                          - Building Tsdl_consts.mlpack
                  - Building tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building tsdl_consts.mly
                                  - Building tsdl_consts.mll
                          - Building tsdl_consts.mlpack
                  - Building src/Tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building src/Tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building src/Tsdl_consts.mly
                                  - Building src/Tsdl_consts.mll
                          - Building src/Tsdl_consts.mlpack
                  - Building src/tsdl_consts.cmx:
                      - Failed to build all of these:
                          - Building src/tsdl_consts.ml:
                              - Failed to build all of these:
                                  - Building support/consts.byte:
                                      - Building support/consts_stub.o
                                  - Building src/tsdl_consts.mly
                                  - Building src/tsdl_consts.mll
                          - Building src/tsdl_consts.mlpack
pkg.ml: [ERROR] cmd ["ocamlbuild" "-use-ocamlfind" "-classic-display" "-j" "4" "-tag" "debug"
     "-build-dir" "_build" "opam" "pkg/META" "CHANGES.md" "LICENSE.md"
     "README.md" "src/tsdl.lib" "src/tsdl.cmxs" "src/tsdl.cmxa"
     "src/tsdl.cma" "src/tsdl.cmx" "src/tsdl.cmi" "src/tsdl.mli"
     "src/tsdl_consts.cmx" "src/tsdl_top.lib" "src/tsdl_top.cmxs"
     "src/tsdl_top.cmxa" "src/tsdl_top.cma" "src/tsdl_top.cmx"
     "src/tsdl_top_init.ml" "src/dlltsdl.dll" "src/libtsdl.lib"
     "doc/index.mld" "README.md" "CHANGES.md" "test/min.ml" "test/minc.c"]: exited with 6
```