### PR TITLE
Use implicit linking with MSVC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 
+- Use implicit linking on MSVC to let ctypes-foreign find SDL2
+  functions on Windows.
 - Add binding to `SDL_SetWindowInputFocus`.
   Thanks to Maxence Guesdon for the patch.
 - Add (-) operation for flags in `Init`, `Renderer` and `Window`.

--- a/_tags
+++ b/_tags
@@ -8,9 +8,10 @@ true: bin_annot, safe_string, thread
 
 <src> : include
 <src/tsdl.{ml,mli}> : package(ctypes), thread
-<src/tsdl.ml> : sdl_consts
+<src/tsdl.ml> : sdl_consts, package(ctypes.foreign)
 <src/tsdl.{cma,cmxa,cmxs}> : custom, thread, \
  package(ctypes), package(ctypes.foreign), use_sdl2
+<src/tsdl_stubs.c> : use_sdl2
 
 <src/libtsdl.*> : use_sdl2
 <src/tsdl_top.*> : package(compiler-libs.toplevel)

--- a/src/tsdl_stubs.c
+++ b/src/tsdl_stubs.c
@@ -5,7 +5,21 @@
 
 /* This is just here for ocamlbuild to generate a correct dlltsdl.so object */
 
+#ifdef _MSC_VER
+/* MSVC requires at least one extern function from SDL2 to be used.
+   If not, MSVC will not link the SDL2 import library and subsequently the
+   SDL2 DLL will not be implicitly linked (aka. load-time dynamic linking)
+   to the TSDL stub DLL. That can be verified with Unix `ldd` or MSVC
+   `dumpbin /imports`.
+   ctypes-foreign, in particular ctypes_win32_dlsym_rtld_default(), requires
+   that all foreign DLLs are already mapped into the process address space.
+   Implicit linking is the simplest way to do that.
+ */
+#include "SDL.h"
+void tsdl_nop (void) { SDL_WasInit(0); return; }
+#else
 void tsdl_nop (void) { return; }
+#endif
 
 /*---------------------------------------------------------------------------
    Copyright (c) 2013 The tsdl programmers


### PR DESCRIPTION
From comments:

```c
/* MSVC requires at least one extern function from SDL2 to be used.
   If not, MSVC will not link the SDL2 import library and subsequently the
   SDL2 DLL will not be implicitly linked (aka. load-time dynamic linking)
   to the TSDL stub DLL. That can be verified with Unix `ldd` or MSVC
   `dumpbin /imports`.
   ctypes-foreign, in particular ctypes_win32_dlsym_rtld_default(), requires
   that all foreign DLLs are already mapped into the process address space.
   Implicit linking is the simplest way to do that.
 */
```

With this PR and the sibling PR #84, I can build a working `tsdl` with MSVC.