### PR TITLE
test/test.ml: Sdl.warp_mouse_global always returns unsupported on wayland

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -1025,7 +1025,11 @@ let test_mouse () =
       ignore (Sdl.show_cursor true);
       ignore (Sdl.get_cursor_shown ());
       Sdl.pump_events ();
-      assert (Sdl.warp_mouse_global ~x:50 ~y:50 = Ok ());
+      let () =
+          match Sdl.warp_mouse_global ~x:50 ~y:50 with
+          | Ok () -> ()
+          | Error (`Msg e) -> log_err "warp_mouse_global: %s" e
+      in
       Sdl.warp_mouse_in_window None ~x:50 ~y:50;
       let current_cursor = Sdl.get_cursor () in
       let default_cursor = Sdl.get_default_cursor () in


### PR DESCRIPTION
The test was failing on wayland, where SDL2 always returns unsupported for warp_mouse_global.
Turn the assertion into a log message instead: the SDL2 documentation does say that this function can fail if the platform doesn't support it.

