### PR TITLE
opam: not available on OpenSUSE Leap

### DIFF
--- a/opam
+++ b/opam
@@ -38,5 +38,6 @@ depends: [
   "ctypes" {>= "0.14.0"}
   "ctypes-foreign"
 ]
+available: [ (os-distribution != "opensuse-leap" | os-version >= 16) ]
 build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
 dev-repo: "git+https://erratique.ch/repos/tsdl.git"


### PR DESCRIPTION
See also https://github.com/ocaml/opam-repository/pull/23235
OpenSUSE Tumbleweed has a much newer SDL2, so lets assume version 16 will have it, and make it unavailable only on <= 15.

The availability condition is useful to avoid 'ocaml-ci' build failures on packages downstream of 'tsdl' too.