### PR TITLE
Sdl: better support for vsync (release runtime lock during Sdl.render_present)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 
+- Sdl.render_present: release runtime lock (useful for 'presentvsync')
 - Use implicit linking on MSVC to let ctypes-foreign find SDL2
   functions on Windows. Thanks to Jonah Beckford for the patch.
 - Add binding to `SDL_SetWindowInputFocus`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 
+- Sdl.gl_get_swap_interval: -1 is a valid return value (adaptive vsync)
 - Sdl.render_present: release runtime lock (useful for 'presentvsync')
 - Use implicit linking on MSVC to let ctypes-foreign find SDL2
   functions on Windows. Thanks to Jonah Beckford for the patch.

--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -2279,8 +2279,18 @@ let gl_get_drawable_size win =
   gl_get_drawable_size win w h;
   (!@ w, !@ h)
 
+let nat_to_maybe_error =
+  let read = function
+       | n when n < 0 ->
+          (match error () with
+          | Error (`Msg "") -> Ok n
+          | err -> err)
+      | n -> Ok n in
+  view ~read ~write:write_never int
+
 let gl_get_swap_interval =
-  foreign "SDL_GL_GetSwapInterval" (void @-> returning nat_to_ok)
+  clear_error ();
+  foreign "SDL_GL_GetSwapInterval" (void @-> returning nat_to_maybe_error)
 
 let gl_make_current =
   foreign "SDL_GL_MakeCurrent"

--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -1567,7 +1567,7 @@ let render_get_viewport rend =
   r
 
 let render_present =
-  foreign "SDL_RenderPresent" (renderer @-> returning void)
+  foreign ~release_runtime_lock:true "SDL_RenderPresent" (renderer @-> returning void)
 
 let render_read_pixels =
   foreign "SDL_RenderReadPixels"

--- a/src/tsdl.ml
+++ b/src/tsdl.ml
@@ -2279,18 +2279,12 @@ let gl_get_drawable_size win =
   gl_get_drawable_size win w h;
   (!@ w, !@ h)
 
-let nat_to_maybe_error =
-  let read = function
-       | n when n < 0 ->
-          (match error () with
-          | Error (`Msg "") -> Ok n
-          | err -> err)
-      | n -> Ok n in
+let int_to_ok =
+  let read n = Ok n in
   view ~read ~write:write_never int
 
 let gl_get_swap_interval =
-  clear_error ();
-  foreign "SDL_GL_GetSwapInterval" (void @-> returning nat_to_maybe_error)
+  foreign "SDL_GL_GetSwapInterval" (void @-> returning int_to_ok)
 
 let gl_make_current =
   foreign "SDL_GL_MakeCurrent"

--- a/test/test.ml
+++ b/test/test.ml
@@ -890,9 +890,17 @@ let test_opengl_contexts () =
                 (m land Sdl.Gl.context_profile_es <> 0)
           end;
           assert (Sdl.gl_extension_supported "BLA234241" = false);
+          Sdl.clear_error ();
           begin match (Sdl.gl_set_swap_interval 1) with
           | Error (`Msg e) -> log_err " Could not set swap interval: %s" e
-          | Ok () -> assert (Sdl.gl_get_swap_interval () = Ok 1)
+          | Ok () ->
+            match Sdl.gl_get_swap_interval () with
+            | Ok 1 -> ()
+            | Ok -1 ->
+                (* might be expected on wayland *)
+                log_err "swap interval is -1 (adaptive)"
+            | Ok n -> log_err "Expected swap interval 1, got %d" n; assert false
+            | Error (`Msg e) -> log_err "Cannot get GL swap interval: %s" e; assert false
           end;
           assert (Sdl.gl_make_current w ctx = Ok ());
           begin match Sdl.gl_get_current_context () with


### PR DESCRIPTION
Sdl.render_present can take up to ~16ms depending on monitor refresh rate, and the OCaml runtime lock should be released during this time.

Also fix behaviour of 'Sdl.gl_get_swap_interval' where '-1' is apparently a valid value (for adaptive vsync), and certain drivers only support 0 or -1 here.