### PR TITLE
Use libNAME.lib and dllNAME.dl in .cma/cmxa for MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 _b0
 tmp
 *.install
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ _build
 _b0
 tmp
 *.install
-.vscode

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 
 
 - Use package `ctypes-foreign` instead of `ctypes.foreign`.
-- Reference `libNAME.lib` and `dllNAME.dll` inside .cma/.cmxa for MSVC.
+- Reference `libNAME.lib` and `dllNAME.dll` inside .cma and .cmxa for MSVC.
 
 v1.0.0 2023-03-16 La Forclaz (VS)
 ---------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 
 
 - Use package `ctypes-foreign` instead of `ctypes.foreign`.
+- Reference `libNAME.lib` and `dllNAME.dll` inside .cma/.cmxa for MSVC.
 
 v1.0.0 2023-03-16 La Forclaz (VS)
 ---------------------------------

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -13,23 +13,28 @@ let pkg_config ?(of_arg=Fun.id) flags package =
   in
   with_temp_file "pkgconfig" "pkg-config" cmd
 
+let parse_char_option ch opt =
+  let len = String.length opt in
+  if len <= 2 then
+    None
+  else
+    match opt.[0], opt.[1] with
+    | '-', ch -> Some (String.sub opt 2 (len - 2))
+    | _, _ -> None
+
 (* Confer: https://github.com/ocaml/dune/issues/119 *)
 let msvc_hack_lib =
   match !Ocamlbuild_plugin.Options.ext_lib with
   | "lib" -> fun ~prefix ~ext lib -> (
-    let len = String.length lib in
-    if len <= 2 then
-      lib
-    else
-      (* drop `-l` prefix *)
-      match lib.[0], lib.[1] with
-      | '-', 'l' -> prefix ^ String.sub lib 2 (len - 2) ^ ext
-      | _, _ -> lib)
+    (* drop `-l` prefix *)
+    match parse_char_option 'l' lib with
+    | Some lib' -> prefix ^ lib' ^ ext
+    | None -> lib)
   | _ -> fun ~prefix ~ext lib -> lib
 
 let pkg_config_lib ~lib ~has_lib ~stublib =
   let cflags = (A has_lib) :: pkg_config "cflags" lib in
-  (* Caution: [-l] is expected by pkg-config conventions, but MSVC does not
+  (* [-l] is expected by pkg-config conventions, but MSVC does not
      support it. Use msvc_hack_lib *)
   let dl_stub_l = [
     A (msvc_hack_lib ~prefix:"dll" ~ext:".dll" (Printf.sprintf "-l%s" stublib))
@@ -42,14 +47,37 @@ let pkg_config_lib ~lib ~has_lib ~stublib =
       lib
   in
   let libs_L = pkg_config "libs-only-L" lib in
+  let libs_other = pkg_config "libs-only-other" lib in
+  let mklib_extra =
+    (* The chain of programs for Windows linking is: ocamlmklib > flexlink > link.
+       To get the [libs-only-other] libraries down to `link` it is best to use
+       the absolute path to the library. *)
+    match !Ocamlbuild_plugin.Options.ext_lib with
+    | "lib" ->
+      let only_A = function | A s -> Some s | _ -> None in
+      let dot_libs =
+        List.filter_map only_A libs_other
+        |> List.filter (String.ends_with ~suffix:".lib")
+      in
+      let args =
+        List.filter_map only_A libs_L
+        |> List.filter_map (parse_char_option 'L')
+        |> List.map (fun libdir -> List.map (fun n -> libdir ^ "/" ^ n) dot_libs)
+        |> List.flatten
+        |> List.filter (Sys.file_exists)
+        |> List.map (fun s -> A s)
+      in
+      [ S args ]
+    | _ -> []
+  in
   let linker = match os with
   | "Linux\n" -> [A "-Wl,-no-as-needed"]
   | _ -> []
   in
   let make_opt o arg = S [ A o; arg ] in
-  let mklib_flags = (List.map (make_opt "-ldopt") linker) @ libs_l @ libs_L in
+  let mklib_flags = (List.map (make_opt "-ldopt") linker) @ libs_l @ libs_L @ mklib_extra in
   let compile_flags = List.map (make_opt "-ccopt") cflags in
-  let lib_flags = List.map (make_opt "-cclib") cc_libs_l in
+  let lib_flags = List.map (make_opt "-cclib") (cc_libs_l @ libs_other) in
   let link_flags = List.map (make_opt "-ccopt") (linker @ libs_L) in
   let stublib_flags = List.map (make_opt "-dllib") dl_stub_l  in
   let tag = Printf.sprintf "use_%s" lib in

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -5,81 +5,39 @@ open Command
 
 let os = Ocamlbuild_pack.My_unix.run_and_read "uname -s"
 
-let pkg_config ?(of_arg=Fun.id) flags package =
+let pkg_config flags package =
   let cmd tmp =
     Command.execute ~quiet:true &
     Cmd( S [ A "pkg-config"; A ("--" ^ flags); A package; Sh ">"; A tmp]);
-    List.map (fun arg -> A (of_arg arg)) (string_list_of_file tmp)
+    List.map (fun arg -> A arg) (string_list_of_file tmp)
   in
   with_temp_file "pkgconfig" "pkg-config" cmd
 
-let parse_char_option ch opt =
-  let len = String.length opt in
-  if len <= 2 then
-    None
-  else
-    match opt.[0], opt.[1] with
-    | '-', ch -> Some (String.sub opt 2 (len - 2))
-    | _, _ -> None
-
-(* Confer: https://github.com/ocaml/dune/issues/119 *)
-let msvc_hack_lib =
-  match !Ocamlbuild_plugin.Options.ext_lib with
-  | "lib" -> fun ~prefix ~ext lib -> (
-    (* drop `-l` prefix *)
-    match parse_char_option 'l' lib with
-    | Some lib' -> prefix ^ lib' ^ ext
-    | None -> lib)
-  | _ -> fun ~prefix ~ext lib -> lib
-
 let pkg_config_lib ~lib ~has_lib ~stublib =
   let cflags = (A has_lib) :: pkg_config "cflags" lib in
-  (* [-l] is expected by pkg-config conventions, but MSVC does not
-     support it. Use msvc_hack_lib *)
-  let dl_stub_l = [
-    A (msvc_hack_lib ~prefix:"dll" ~ext:".dll" (Printf.sprintf "-l%s" stublib))
-  ] in
-  let libs_l = pkg_config "libs-only-l" lib in
-  let cc_libs_l =
-    pkg_config
-      ~of_arg:(msvc_hack_lib ~prefix:"" ~ext:".lib")
-      "libs-only-l"
-      lib
+  let stub_l = match !Ocamlbuild_plugin.Options.ext_lib with
+  | "lib" -> [A (Printf.sprintf "dll%s.dll" stublib)]
+  | _ -> [A (Printf.sprintf "-l%s" stublib)]
   in
+  let libs_l = pkg_config "libs-only-l" lib in
   let libs_L = pkg_config "libs-only-L" lib in
   let libs_other = pkg_config "libs-only-other" lib in
-  let mklib_extra =
-    (* The chain of programs for Windows linking is: ocamlmklib > flexlink > link.
-       To get the [libs-only-other] libraries down to `link` it is best to use
-       the absolute path to the library. *)
-    match !Ocamlbuild_plugin.Options.ext_lib with
-    | "lib" ->
-      let only_A = function | A s -> Some s | _ -> None in
-      let dot_libs =
-        List.filter_map only_A libs_other
-        |> List.filter (String.ends_with ~suffix:".lib")
-      in
-      let args =
-        List.filter_map only_A libs_L
-        |> List.filter_map (parse_char_option 'L')
-        |> List.map (fun libdir -> List.map (fun n -> libdir ^ "/" ^ n) dot_libs)
-        |> List.flatten
-        |> List.filter (Sys.file_exists)
-        |> List.map (fun s -> A s)
-      in
-      [ S args ]
-    | _ -> []
+  let mklib_extra = match !Ocamlbuild_plugin.Options.ext_lib with
+  | "lib" -> [ S libs_L ]
+  | _ -> []
   in
   let linker = match os with
   | "Linux\n" -> [A "-Wl,-no-as-needed"]
   | _ -> []
   in
   let make_opt o arg = S [ A o; arg ] in
-  let mklib_flags = (List.map (make_opt "-ldopt") linker) @ libs_l @ libs_L @ mklib_extra in
+  let mklib_flags = (List.map (make_opt "-ldopt") linker)
+    @ libs_l @ libs_L @ mklib_extra
+  in
   let compile_flags = List.map (make_opt "-ccopt") cflags in
-  let lib_flags = List.map (make_opt "-cclib") (cc_libs_l @ libs_other) in
+  let lib_flags = List.map (make_opt "-cclib") (libs_l @ libs_other) in
   let link_flags = List.map (make_opt "-ccopt") (linker @ libs_L) in
-  let stublib_flags = List.map (make_opt "-dllib") dl_stub_l  in
+  let stublib_flags = List.map (make_opt "-dllib") stub_l  in
   let tag = Printf.sprintf "use_%s" lib in
   flag ["c"; "ocamlmklib"; tag] (S mklib_flags);
   flag ["c"; "compile"; tag] (S compile_flags);


### PR DESCRIPTION
This is a fix for https://github.com/dbuenzli/tsdl/issues/96

### Before (1.0.0)

```
$ del -force -Recurse _build ; Y:\source\dksdk-coder\msys64\usr\bin\bash -lc 'PATH="/y/source/dksdk-coder/.ci/sd4/opamrun:$PATH"; opamrun exec -- ocaml pkg/pkg.ml build'

...
 ocamlfind ocamlmklib -o src/tsdl -g -LY:/source/dksdk-coder/.ci/o/dkml/bin/../lib src/tsdl_stubs.obj
...

$ with-dkml ldd .\_build\src\dlltsdl.dll
Cannot find FLEXDLL_RELOCATE
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7fff60b10000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7fff5f150000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7fff5e1f0000)
        msvcrt.dll => /c/WINDOWS/System32/msvcrt.dll (0x7fff5f810000)
        dlltsdl.dll => /y/source/tsdl/_build/src/dlltsdl.dll (0x60bf0000)
        ucrtbase.dll => /c/Windows/System32/ucrtbase.dll (0x7fff5de50000)
        vcruntime140.dll => /c/Windows/System32/vcruntime140.dll (0x7fff4d050000)
```

And see https://github.com/dbuenzli/tsdl/issues/96 for ocamlobjinfo of `tsdl.cma`

### After (1.0.0 + PR)

Notice `SDL2.dll` is listed as a runtime dependency.

```
$ del -force -Recurse _build ; Y:\source\dksdk-coder\msys64\usr\bin\bash -lc 'PATH="/y/source/dksdk-coder/.ci/sd4/opamrun:$PATH"; opamrun exec -- ocaml pkg/pkg.ml build'

...
 ocamlfind ocamlmklib -o src/tsdl -g -LY:/source/dksdk-coder/.ci/o/dkml/bin/../lib Y:/source/dksdk-coder/.ci/o/dkml/bin/../lib/SDL2.lib src/tsdl_stubs.obj
...

$ with-dkml ldd .\_build\src\dlltsdl.dll
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7fff60b10000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7fff5f150000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7fff5e1f0000)
        msvcrt.dll => /c/WINDOWS/System32/msvcrt.dll (0x7fff5f810000)
        dlltsdl.dll => /y/source/tsdl/_build/src/dlltsdl.dll (0x60bf0000)
        ucrtbase.dll => /c/Windows/System32/ucrtbase.dll (0x7fff5de50000)
        vcruntime140.dll => /c/Windows/System32/vcruntime140.dll (0x7fff4d050000)
        SDL2.dll => not found
        api-ms-win-crt-environment-l1-1-0.dll => /c/Program Files (x86)/Microsoft Visual Studio/2019/Community/Common7/IDE/api-ms-win-crt-environment-l1-1-0.dll (?)
        api-ms-win-crt-stdio-l1-1-0.dll => /c/Program Files (x86)/Microsoft Visual Studio/2019/Community/Common7/IDE/api-ms-win-crt-stdio-l1-1-0.dll (?)
        api-ms-win-crt-runtime-l1-1-0.dll => /c/Program Files (x86)/Microsoft Visual Studio/2019/Community/Common7/IDE/api-ms-win-crt-runtime-l1-1-0.dll (?)
```

Here is ocamlobjinfo for `tsdl.cma`:

```
File y:\source\dksdk-coder\.ci\o\dkml\lib\tsdl\tsdl.cma
Force custom: YES
Extra C object files: SDL2.lib
Extra C options: -LY:/source/dksdk-coder/.ci/o/dkml/bin/../lib
Extra dynamically-loaded libraries: dlltsdl.dll
```