### PR TITLE
implement SDL_Vertex and SDL_RenderGeometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tsdl — Thin bindings to SDL for OCaml
 Tsdl is an OCaml library providing thin bindings to the cross-platform
 SDL C library.
 
-Tsdl depends on the [SDL 2.0.10][sdl] C library (or later),
+Tsdl depends on the [SDL 2.0.18][sdl] C library (or later),
 [ocaml-ctypes][ctypes] and the `result` compatibility package.
 Tsdl is distributed under the ISC license.
 
@@ -17,7 +17,7 @@ Home page: http://erratique.ch/software/tsdl
 
 ## Installation
 
-Tsdl needs the C library SDL 2.0.9 or later installed on your
+Tsdl needs the C library SDL 2.0.18 or later installed on your
 system. Tsdl can be installed with `opam`:
 
     opam install tsdl

--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -435,6 +435,18 @@ val rect_equals : rect -> rect -> bool
 val union_rect : rect -> rect -> rect
 (** {{:http://wiki.libsdl.org/SDL_UnionRect}SDL_UnionRect} *)
 
+type vertex
+
+module Vertex : sig
+  val create : position:fpoint -> color:color -> tex_coord:fpoint -> vertex
+  val position : vertex -> fpoint
+  val color : vertex -> color
+  val tex_coord : vertex -> fpoint
+  val set_position : vertex -> fpoint -> unit
+  val set_color : vertex -> color -> unit
+  val set_tex_coord : vertex -> fpoint -> unit
+end
+
 (** {2:palettes {{:http://wiki.libsdl.org/CategoryPixels}Palettes}} *)
 
 type palette
@@ -983,6 +995,10 @@ val render_fill_rects_ba : renderer -> (int32, Bigarray.int32_elt) bigarray ->
 
     @raise Invalid_argument if the length of the array is not a
     multiple of 4. *)
+
+val render_geometry : ?indices:(int list) -> ?texture:texture -> renderer -> vertex list -> 
+  unit result
+(** {{:http://wiki.libsdl.org/SDL_RenderGeometry}SDL_RenderGeometry} *)
 
 val render_get_clip_rect : renderer -> rect
 (** {{:http://wiki.libsdl.org/SDL_RenderGetClipRect}SDL_RenderGetClipRect} *)

--- a/src/tsdl.mli
+++ b/src/tsdl.mli
@@ -345,6 +345,27 @@ module Color : sig
   val set_a : color -> uint8 -> unit
 end
 
+module Color_ba : sig
+  type t = (int, Bigarray.int8_unsigned_elt) bigarray
+  val create : int -> t
+  val set : int -> r:int -> g:int -> b:int -> a:int -> t -> unit
+  val set_color : int -> color -> t -> unit
+  val get : int -> t -> int * int * int * int
+  (** Colors are returned as (R, G, B, A) *)
+
+  val get_color : int -> t -> color
+end
+(** Used to store a packed array of colors. SDL's color
+    representation is sensitive to endianness (see
+    {{:https://wiki.libsdl.org/SDL_Color}SDL_Color}). This
+    module takes care of endianness concerns.
+
+    Note that the indices used by set, get, etc. are the
+    indices of the colors, rather than the bytes. Accessing
+    the 3rd color, for instance, will access bytes 12, 13,
+    14 and 15. *)
+
+
 (** {2:points Points} *)
 
 type point
@@ -1002,6 +1023,30 @@ val render_fill_rects_ba : renderer -> (int32, Bigarray.int32_elt) bigarray ->
 val render_geometry : ?indices:(int list) -> ?texture:texture -> renderer -> vertex list -> 
   unit result
 (** {{:http://wiki.libsdl.org/SDL_RenderGeometry}SDL_RenderGeometry} *)
+
+val render_geometry_raw : ?indices:(int32, Bigarray.int32_elt) bigarray -> ?texture:texture -> renderer -> (float, Bigarray.float32_elt) bigarray -> (int, Bigarray.int8_unsigned_elt) bigarray -> (float, Bigarray.float32_elt) bigarray -> unit result
+(** {{:http://wiki.libsdl.org/SDL_RenderGeometryRaw}SDL_RenderGeometryRaw}
+
+    This function is provided with only a bigarray interface. In
+    contrast to SDL's version, this version does not provide 'stride'
+    arguments. Indices are assumed to be signed 32-bit integers as the
+    type signature suggests.
+
+    Each consecutive pair in xy is a coordinate. Each consecutive quadruple
+    in color is a color. On little-endian machines, colors should be encoded
+    in the byte order R, G, B, A from lowest to highest index; and on
+    big-endian machines, they should be encoded as A, B, G, R, again
+    lowest to highest index. Each consecutive pair in uv is a coordinate.
+
+    @raise Invalid_argument if the length of the xy and uv arrays are
+    not multiples of 2.
+
+    @raise Invalid_argument if the length of the color array is not a
+    multiple of 4.
+
+    @raise Invalid_argument if the number of xy points, colors, and uv
+    points is not equal.
+  *)
 
 val render_get_clip_rect : renderer -> rect
 (** {{:http://wiki.libsdl.org/SDL_RenderGetClipRect}SDL_RenderGetClipRect} *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -117,6 +117,24 @@ let test_colors () =
   assert (Sdl.Color.a c = 4);
   ()
 
+let test_color_bas () =
+  log "Testing color_bas";
+  let cs = Sdl.Color_ba.create 1 in
+  let c = Sdl.Color.create ~r:101 ~g:102 ~b:103 ~a:104 in
+  Sdl.Color_ba.set 0 ~r:123 ~g:222 ~b:211 ~a:100 cs;
+  (* testing Color_ba.get and Color_ba.set *)
+  assert (Sdl.Color_ba.get 0 cs = (123, 222, 211, 100));
+  Sdl.Color_ba.set_color 0 c cs;
+  (* testing Color_ba.set_color *)
+  assert (Sdl.Color_ba.get 0 cs = (101, 102, 103, 104));
+  let c' = Sdl.Color_ba.get_color 0 cs in
+  (* testing Color_ba.get_color *)
+  assert (Sdl.Color.r c' = 101);
+  assert (Sdl.Color.g c' = 102);
+  assert (Sdl.Color.b c' = 103);
+  assert (Sdl.Color.a c' = 104);
+  ()
+
 let test_points () =
   log "Testing points";
   let p = Sdl.Point.create ~x:1 ~y:2 in
@@ -585,6 +603,24 @@ let test_renderers () =
           assert (Sdl.render_geometry r vertices ~indices = Ok ());
           assert (Sdl.render_geometry r vertices ~texture:t = Ok ());
           assert (Sdl.render_geometry r vertices ~texture:t ~indices = Ok ());
+          let xy_ba = create_bigarray Bigarray.float32 6 in
+          let color_ba = create_bigarray Bigarray.int8_unsigned 12 in
+          let uv_ba = create_bigarray Bigarray.float32 6 in
+          let indices_ba = create_bigarray Bigarray.int32 3 in
+          xy_ba.{0} <- 10.5; xy_ba.{1} <- 10.5;
+          xy_ba.{2} <- 20.5; xy_ba.{3} <- 10.5;
+          xy_ba.{4} <- 10.5; xy_ba.{5} <- 20.5;
+          color_ba.{0} <- 255; color_ba.{1} <- 0; color_ba.{2} <- 0; color_ba.{3} <- 255;
+          color_ba.{4} <- 0; color_ba.{5} <- 255; color_ba.{6} <- 0; color_ba.{7} <- 255;
+          color_ba.{8} <- 0; color_ba.{9} <- 0; color_ba.{10} <- 255; color_ba.{11} <- 255;
+          uv_ba.{0} <- 1.; uv_ba.{1} <- 1.;
+          uv_ba.{2} <- 1.; uv_ba.{3} <- 1.;
+          uv_ba.{4} <- 1.; uv_ba.{5} <- 1.;
+          indices_ba.{0} <- 2l; indices_ba.{1} <- 1l; indices_ba.{2} <- 0l;
+          assert (Sdl.render_geometry_raw r xy_ba color_ba uv_ba = Ok ());
+          assert (Sdl.render_geometry_raw ~indices:indices_ba r xy_ba color_ba uv_ba = Ok ());
+          assert (Sdl.render_geometry_raw ~texture:t r xy_ba color_ba uv_ba = Ok ());
+          assert (Sdl.render_geometry_raw ~texture:t ~indices:indices_ba r xy_ba color_ba uv_ba = Ok ());
           Sdl.destroy_texture t;
           Sdl.render_present r;
           test_vsync r;
@@ -1590,6 +1626,7 @@ let tests human = match Sdl.init Sdl.Init.everything with
     test_rw_ops ();
     test_file_system_paths ();
     test_colors ();
+    test_color_bas ();
     test_points ();
     test_rectangles ();
     test_vertices ();

--- a/test/test.ml
+++ b/test/test.ml
@@ -176,6 +176,30 @@ let test_rectangles () =
             (Sdl.Rect.create ~x:0 ~y:0 ~w:2 ~h:2));
   ()
 
+let test_vertices () =
+  log "Testing vertices";
+  let eq_fpoint f1 f2 = Sdl.Fpoint.(x f1 = x f2 && y f1 = y f2) in
+  let eq_color c1 c2 = Sdl.Color.(r c1 = r c2 && g c1 = g c2 && b c1 = b c2 && a c1 = a c2) in
+  let position = Sdl.Fpoint.create ~x:123.0 ~y:456.0 in 
+  let color = Sdl.Color.create ~r:70 ~g:200 ~b:135 ~a:50 in 
+  let tex_coord = Sdl.Fpoint.create ~x:1.1 ~y:2.2 in
+  let vertex = Sdl.Vertex.create ~position ~color ~tex_coord in 
+  assert (eq_fpoint (Sdl.Vertex.position vertex) position);
+  assert (eq_color (Sdl.Vertex.color vertex) color);
+  assert (eq_fpoint (Sdl.Vertex.tex_coord vertex) tex_coord);
+ 
+  let position' = Sdl.Fpoint.create ~x:987.0 ~y:444.0 in
+  let color' = Sdl.Color.create ~r:88 ~g:123 ~b:95 ~a:254 in
+  let tex_coord' = Sdl.Fpoint.create ~x:2.3 ~y:4.1 in
+
+  Sdl.Vertex.set_position vertex position';
+  assert (eq_fpoint (Sdl.Vertex.position vertex) position');
+  Sdl.Vertex.set_color vertex color';
+  assert (eq_color (Sdl.Vertex.color vertex) color');
+  Sdl.Vertex.set_tex_coord vertex tex_coord';
+  assert (eq_fpoint (Sdl.Vertex.tex_coord vertex) tex_coord');
+  ()
+
 let test_palettes () =
   log "Testing palettes";
   let eq_col c0 c1 =
@@ -532,6 +556,36 @@ let test_renderers () =
           assert (Sdl.set_render_draw_color r 0xFF 0xFF 0xFF 0xFF = Ok ());
           assert (Sdl.render_draw_rects r rects = Ok ());
           assert (Sdl.render_draw_rects_ba r rects_ba = Ok ());
+          let v1 =
+            Sdl.Vertex.create
+              ~position:(Sdl.Fpoint.create ~x:10.5 ~y:10.5) 
+              ~color:(Sdl.Color.create ~r:255 ~g:0 ~b:0 ~a:255)
+              ~tex_coord:(Sdl.Fpoint.create ~x:1.0 ~y:1.0)
+          in
+          let v2 =
+            Sdl.Vertex.create
+              ~position:(Sdl.Fpoint.create ~x:20.5 ~y:10.5)
+              ~color:(Sdl.Color.create ~r:255 ~g:0 ~b:0 ~a:255)
+              ~tex_coord:(Sdl.Fpoint.create ~x:1.0 ~y:1.0)
+          in
+          let v3 =
+            Sdl.Vertex.create
+              ~position:(Sdl.Fpoint.create ~x:10.5 ~y:20.5)
+              ~color:(Sdl.Color.create ~r:255 ~g:0 ~b:0 ~a:255)
+              ~tex_coord:(Sdl.Fpoint.create ~x:1.0 ~y:1.0)
+          in
+          let vertices = [v1; v2; v3] in 
+          let indices = [2; 1; 0] in
+          let t =
+            match Sdl.create_texture r Sdl.Pixel.format_rgba8888 Sdl.Texture.access_target ~w:100 ~h:100 with
+            | Ok t -> t
+            | Error _ -> assert false
+          in
+          assert (Sdl.render_geometry r vertices = Ok ());
+          assert (Sdl.render_geometry r vertices ~indices = Ok ());
+          assert (Sdl.render_geometry r vertices ~texture:t = Ok ());
+          assert (Sdl.render_geometry r vertices ~texture:t ~indices = Ok ());
+          Sdl.destroy_texture t;
           Sdl.render_present r;
           test_vsync r;
           assert (Sdl.get_render_target r = None);
@@ -1538,6 +1592,7 @@ let tests human = match Sdl.init Sdl.Init.everything with
     test_colors ();
     test_points ();
     test_rectangles ();
+    test_vertices ();
     test_palettes ();
     test_pixel_formats ();
     test_surfaces ();


### PR DESCRIPTION
This pull request implements the SDL_Vertex type and SDL_RenderGeometry function for TSDL. SDL_RenderGeometry renders an arbitrary list of vertices, by default in order but optionally in a user-specified order. It requires SDL version 2.0.18 or later and should not be merged until TSDL is ready for SDL 2.0.18. 